### PR TITLE
Add Polars append prop data helper

### DIFF
--- a/cfa/stf/forecasttools/__init__.py
+++ b/cfa/stf/forecasttools/__init__.py
@@ -3,6 +3,7 @@
 from importlib import import_module
 
 from .location_table import LOCATION_LIST
+from .prop_data import append_prop_data
 from .utils import coalesce_common_columns
 
 
@@ -16,6 +17,7 @@ def __getattr__(name):
 
 __all__ = [
     "coalesce_common_columns",
+    "append_prop_data",
     "get_us_loc_pop_tbl",
     "LOCATION_LIST",
     "arviz",

--- a/cfa/stf/forecasttools/prop_data.py
+++ b/cfa/stf/forecasttools/prop_data.py
@@ -1,38 +1,35 @@
 import polars as pl
-
-OBSERVED_ED_VISITS_VAR = "observed_ed_visits"
-OTHER_ED_VISITS_VAR = "other_ed_visits"
-PROP_DISEASE_ED_VISITS_VAR = "prop_disease_ed_visits"
+import polars.selectors as cs
 
 
 def append_prop_data(
     data: pl.DataFrame,
-    observed_var: str = OBSERVED_ED_VISITS_VAR,
-    other_var: str = OTHER_ED_VISITS_VAR,
-    prop_var: str = PROP_DISEASE_ED_VISITS_VAR,
+    observed_var: str = "observed_ed_visits",
+    other_var: str = "other_ed_visits",
+    prop_var: str = "prop_disease_ed_visits",
 ) -> pl.DataFrame:
     """Append disease ED visit proportion rows to combined surveillance data."""
     required_columns = {"date", ".variable", ".value"}
-    missing_columns = required_columns.difference(data.columns)
-    if missing_columns:
+    if missing_columns := required_columns.difference(data.columns):
         missing = ", ".join(sorted(missing_columns))
         raise ValueError(f"data is missing required column(s): {missing}")
 
     value_vars = [observed_var, other_var]
-    id_columns = [col for col in data.columns if col not in {".variable", ".value"}]
 
     prop_data = data.filter(pl.col(".variable").is_in(value_vars)).pivot(
         on=".variable",
-        index=id_columns,
+        index=cs.exclude(".variable", ".value"),
         values=".value",
     )
-    prop_data = prop_data.select(
-        [
-            col
-            for col in prop_data.columns
-            if not prop_data.get_column(col).is_null().all()
-        ]
+    all_null_columns = (
+        prop_data.select(cs.all().is_null().all()).row(0, named=True).items()
     )
+    all_null_columns = [
+        column for column, column_is_all_null in all_null_columns if column_is_all_null
+    ]
+    if all_null_columns:
+        prop_data = prop_data.select(cs.exclude(all_null_columns))
+
     prop_data = prop_data.with_columns(
         pl.lit(prop_var).alias(".variable"),
         (pl.col(observed_var) / (pl.col(observed_var) + pl.col(other_var))).alias(

--- a/cfa/stf/forecasttools/prop_data.py
+++ b/cfa/stf/forecasttools/prop_data.py
@@ -21,15 +21,6 @@ def append_prop_data(
         index=cs.exclude(".variable", ".value"),
         values=".value",
     )
-    all_null_columns = (
-        prop_data.select(cs.all().is_null().all()).row(0, named=True).items()
-    )
-    all_null_columns = [
-        column for column, column_is_all_null in all_null_columns if column_is_all_null
-    ]
-    if all_null_columns:
-        prop_data = prop_data.select(cs.exclude(all_null_columns))
-
     prop_data = prop_data.with_columns(
         pl.lit(prop_var).alias(".variable"),
         (pl.col(observed_var) / (pl.col(observed_var) + pl.col(other_var))).alias(

--- a/cfa/stf/forecasttools/prop_data.py
+++ b/cfa/stf/forecasttools/prop_data.py
@@ -1,0 +1,45 @@
+import polars as pl
+
+OBSERVED_ED_VISITS_VAR = "observed_ed_visits"
+OTHER_ED_VISITS_VAR = "other_ed_visits"
+PROP_DISEASE_ED_VISITS_VAR = "prop_disease_ed_visits"
+
+
+def append_prop_data(
+    data: pl.DataFrame,
+    observed_var: str = OBSERVED_ED_VISITS_VAR,
+    other_var: str = OTHER_ED_VISITS_VAR,
+    prop_var: str = PROP_DISEASE_ED_VISITS_VAR,
+) -> pl.DataFrame:
+    """Append disease ED visit proportion rows to combined surveillance data."""
+    required_columns = {"date", ".variable", ".value"}
+    missing_columns = required_columns.difference(data.columns)
+    if missing_columns:
+        missing = ", ".join(sorted(missing_columns))
+        raise ValueError(f"data is missing required column(s): {missing}")
+
+    value_vars = [observed_var, other_var]
+    id_columns = [col for col in data.columns if col not in {".variable", ".value"}]
+
+    prop_data = data.filter(pl.col(".variable").is_in(value_vars)).pivot(
+        on=".variable",
+        index=id_columns,
+        values=".value",
+    )
+    prop_data = prop_data.select(
+        [
+            col
+            for col in prop_data.columns
+            if not prop_data.get_column(col).is_null().all()
+        ]
+    )
+    prop_data = prop_data.with_columns(
+        pl.lit(prop_var).alias(".variable"),
+        (pl.col(observed_var) / (pl.col(observed_var) + pl.col(other_var))).alias(
+            ".value"
+        ),
+    ).drop(value_vars)
+
+    return pl.concat([data, prop_data], how="diagonal_relaxed").sort(
+        "date", ".variable", maintain_order=True
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
 ]
 
 [project.urls]
-Repository = "https://github.com/CDCgov/forecasttools-py"
-Issues = "https://github.com/CDCgov/forecasttools-py/issues"
+Repository = "https://github.com/CDCgov/cfa-stf-forecasttools"
+Issues = "https://github.com/CDCgov/cfa-stf-forecasttools/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["cfa"]

--- a/tests/cfa/stf/forecasttools/test_prop_data.py
+++ b/tests/cfa/stf/forecasttools/test_prop_data.py
@@ -1,0 +1,117 @@
+import polars as pl
+import polars.testing as plt
+import pytest
+
+import cfa.stf.forecasttools as ft
+
+
+def test_append_prop_data_appends_proportion_rows():
+    data = pl.DataFrame(
+        {
+            "date": [
+                "2024-01-02",
+                "2024-01-01",
+                "2024-01-01",
+                "2024-01-02",
+                "2024-01-01",
+            ],
+            "location": ["US", "US", "US", "US", "US"],
+            ".variable": [
+                "other_ed_visits",
+                "observed_ed_visits",
+                "other_ed_visits",
+                "observed_ed_visits",
+                "some_other_variable",
+            ],
+            ".value": [70, 20, 80, 30, 999],
+        }
+    )
+
+    result = ft.append_prop_data(data)
+
+    expected = pl.DataFrame(
+        {
+            "date": [
+                "2024-01-01",
+                "2024-01-01",
+                "2024-01-01",
+                "2024-01-01",
+                "2024-01-02",
+                "2024-01-02",
+                "2024-01-02",
+            ],
+            "location": ["US", "US", "US", "US", "US", "US", "US"],
+            ".variable": [
+                "observed_ed_visits",
+                "other_ed_visits",
+                "prop_disease_ed_visits",
+                "some_other_variable",
+                "observed_ed_visits",
+                "other_ed_visits",
+                "prop_disease_ed_visits",
+            ],
+            ".value": [20.0, 80.0, 0.2, 999.0, 30.0, 70.0, 0.3],
+        }
+    )
+    plt.assert_frame_equal(result, expected)
+
+
+def test_append_prop_data_preserves_additional_identifier_columns():
+    data = pl.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-01", "2024-01-01", "2024-01-01"],
+            "location": ["CA", "CA", "NY", "NY"],
+            "age_group": ["all", "all", "all", "all"],
+            ".variable": [
+                "observed_ed_visits",
+                "other_ed_visits",
+                "observed_ed_visits",
+                "other_ed_visits",
+            ],
+            ".value": [1, 3, 4, 6],
+        }
+    )
+
+    result = ft.append_prop_data(data).filter(
+        pl.col(".variable") == "prop_disease_ed_visits"
+    )
+
+    expected = pl.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-01"],
+            "location": ["CA", "NY"],
+            "age_group": ["all", "all"],
+            ".variable": ["prop_disease_ed_visits", "prop_disease_ed_visits"],
+            ".value": [0.25, 0.4],
+        }
+    )
+    plt.assert_frame_equal(result, expected)
+
+
+def test_append_prop_data_drops_all_null_columns_from_derived_rows():
+    data = pl.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-01"],
+            "all_null_id": [None, None],
+            ".variable": ["observed_ed_visits", "other_ed_visits"],
+            ".value": [1, 1],
+        }
+    )
+
+    result = ft.append_prop_data(data)
+    prop_row = result.filter(pl.col(".variable") == "prop_disease_ed_visits")
+
+    assert prop_row.item(0, ".value") == 0.5
+    assert prop_row.item(0, "all_null_id") is None
+
+
+def test_append_prop_data_errors_when_required_column_is_missing():
+    data = pl.DataFrame(
+        {
+            "date": ["2024-01-01"],
+            ".variable": ["observed_ed_visits"],
+        }
+    )
+
+    with pytest.raises(ValueError, match=r"\.value"):
+        ft.append_prop_data(data)

--- a/tests/cfa/stf/forecasttools/test_prop_data.py
+++ b/tests/cfa/stf/forecasttools/test_prop_data.py
@@ -88,23 +88,6 @@ def test_append_prop_data_preserves_additional_identifier_columns():
     plt.assert_frame_equal(result, expected)
 
 
-def test_append_prop_data_drops_all_null_columns_from_derived_rows():
-    data = pl.DataFrame(
-        {
-            "date": ["2024-01-01", "2024-01-01"],
-            "all_null_id": [None, None],
-            ".variable": ["observed_ed_visits", "other_ed_visits"],
-            ".value": [1, 1],
-        }
-    )
-
-    result = ft.append_prop_data(data)
-    prop_row = result.filter(pl.col(".variable") == "prop_disease_ed_visits")
-
-    assert prop_row.item(0, ".value") == 0.5
-    assert prop_row.item(0, "all_null_id") is None
-
-
 def test_append_prop_data_errors_when_required_column_is_missing():
     data = pl.DataFrame(
         {


### PR DESCRIPTION
## Summary

Adds a Polars implementation of `append_prop_data()` to derive `prop_disease_ed_visits` rows from `observed_ed_visits` and `other_ed_visits` in combined surveillance data.

The helper operates on an in-memory `pl.DataFrame`, preserves identifier columns, appends derived rows, and sorts by `date` and `.variable` to match the legacy R behavior.

## Validation

- `uv run pytest tests/cfa/stf/forecasttools/test_prop_data.py`
- Compared legacy R script output with the Python implementation on a TSV fixture; parsed outputs matched, and the downstream routine writer produced byte-identical TSV output.
