### PR TITLE
daily-to-weekly aggregation utility with epiweek/isoweek support

### DIFF
--- a/cfa/stf/forecasttools/__init__.py
+++ b/cfa/stf/forecasttools/__init__.py
@@ -2,7 +2,15 @@
 
 from importlib import import_module
 
-from .aggregate_to_weekly import daily_to_weekly
+from .aggregate_to_weekly import (
+    ceiling_isoweek,
+    ceiling_mmwr_epiweek,
+    ceiling_week,
+    daily_to_weekly,
+    floor_isoweek,
+    floor_mmwr_epiweek,
+    floor_week,
+)
 from .location_table import LOCATION_LIST
 from .prop_data import append_prop_data
 from .utils import coalesce_common_columns
@@ -23,4 +31,10 @@ __all__ = [
     "LOCATION_LIST",
     "arviz",
     "daily_to_weekly",
+    "floor_week",
+    "ceiling_week",
+    "floor_isoweek",
+    "ceiling_isoweek",
+    "floor_mmwr_epiweek",
+    "ceiling_mmwr_epiweek",
 ]

--- a/cfa/stf/forecasttools/__init__.py
+++ b/cfa/stf/forecasttools/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib import import_module
 
+from .aggregate_to_weekly import daily_to_weekly
 from .location_table import LOCATION_LIST
 from .prop_data import append_prop_data
 from .utils import coalesce_common_columns
@@ -21,4 +22,5 @@ __all__ = [
     "get_us_loc_pop_tbl",
     "LOCATION_LIST",
     "arviz",
+    "daily_to_weekly",
 ]

--- a/cfa/stf/forecasttools/aggregate_to_weekly.py
+++ b/cfa/stf/forecasttools/aggregate_to_weekly.py
@@ -234,28 +234,32 @@ def daily_to_weekly(
     ).unnest("week_struct")
 
     group_cols = ["week", "weekyear"] + id_cols
-    n_elements = df.group_by(group_cols).agg(pl.len().alias("n_elements"))
-    problematic_trajectories = n_elements.filter(pl.col("n_elements") > 7)
-    if not problematic_trajectories.is_empty():
+    grouped_df = df.group_by(group_cols).agg(
+        pl.col(value_col).sum().alias(weekly_value_name),
+        pl.len().alias("n_dates"),
+        pl.col(date_col).dt.date().n_unique().alias("n_unique_dates"),
+    )
+
+    duplicate_date_trajectories = grouped_df.filter(
+        pl.col("n_dates") != pl.col("n_unique_dates")
+    )
+    if not duplicate_date_trajectories.is_empty():
         message = (
-            "At least one trajectory has more than 7 values for a given "
+            "At least one trajectory has repeated dates within a given "
             f"week.\n"
-            f"Problematic trajectories with more than 7 values: {problematic_trajectories}"
+            f"Trajectories with repeated dates: {duplicate_date_trajectories}"
         )
         raise ValueError(message)
 
     if strict:
-        valid_groups = n_elements.filter(pl.col("n_elements") == 7)
-        df = df.join(valid_groups.select(group_cols), on=group_cols, how="inner")
+        grouped_df = grouped_df.filter(pl.col("n_unique_dates") == 7)
 
-    df = (
-        df.group_by(group_cols)
-        .agg(pl.col(value_col).sum().alias(weekly_value_name))
-        .sort(group_cols)
+    grouped_df = grouped_df.drop(["n_dates", "n_unique_dates"]).sort(
+        ["weekyear", "week", *id_cols]
     )
 
     if with_week_start_date:
-        df = df.with_columns(
+        grouped_df = grouped_df.with_columns(
             pl.struct(["weekyear", "week"])
             .map_elements(
                 lambda elt: _calculate_week_startdate(
@@ -269,7 +273,7 @@ def daily_to_weekly(
         )
 
     if with_week_end_date:
-        df = df.with_columns(
+        grouped_df = grouped_df.with_columns(
             pl.struct(["weekyear", "week"])
             .map_elements(
                 lambda elt: _calculate_week_enddate(
@@ -282,4 +286,4 @@ def daily_to_weekly(
             .alias(week_end_date_name)
         )
 
-    return df
+    return grouped_df

--- a/cfa/stf/forecasttools/aggregate_to_weekly.py
+++ b/cfa/stf/forecasttools/aggregate_to_weekly.py
@@ -59,7 +59,7 @@ def _calculate_week_enddate(
 
 
 def floor_week(
-    date: datetime.date,
+    date: datetime.date | datetime.datetime,
     standard: WeekStandard | str = "MMWR",
 ) -> datetime.date:
     """Get the first date in an epidemiological week.
@@ -91,7 +91,7 @@ def floor_week(
 
 
 def ceiling_week(
-    date: datetime.date,
+    date: datetime.date | datetime.datetime,
     standard: WeekStandard | str = "MMWR",
 ) -> datetime.date:
     """Get the last date in an epidemiological week.
@@ -123,22 +123,30 @@ def ceiling_week(
     )
 
 
-def floor_isoweek(date: datetime.date) -> datetime.date:
+def floor_isoweek(
+    date: datetime.date | datetime.datetime,
+) -> datetime.date:
     """Get the first date (Monday) in an ISO week."""
     return floor_week(date, standard="ISO")
 
 
-def ceiling_isoweek(date: datetime.date) -> datetime.date:
+def ceiling_isoweek(
+    date: datetime.date | datetime.datetime,
+) -> datetime.date:
     """Get the last date (Sunday) in an ISO week."""
     return ceiling_week(date, standard="ISO")
 
 
-def floor_mmwr_epiweek(date: datetime.date) -> datetime.date:
+def floor_mmwr_epiweek(
+    date: datetime.date | datetime.datetime,
+) -> datetime.date:
     """Get the first date (Sunday) in an MMWR epidemiological week."""
     return floor_week(date, standard="MMWR")
 
 
-def ceiling_mmwr_epiweek(date: datetime.date) -> datetime.date:
+def ceiling_mmwr_epiweek(
+    date: datetime.date | datetime.datetime,
+) -> datetime.date:
     """Get the last date (Saturday) in an MMWR epidemiological week."""
     return ceiling_week(date, standard="MMWR")
 

--- a/cfa/stf/forecasttools/aggregate_to_weekly.py
+++ b/cfa/stf/forecasttools/aggregate_to_weekly.py
@@ -1,0 +1,196 @@
+import datetime
+from typing import Literal
+
+import epiweeks
+import polars as pl
+
+WeekStandard = Literal["epiweek", "isoweek"]
+
+
+def calculate_week_and_year(
+    date_input: datetime.date,
+    standard: WeekStandard = "epiweek",
+) -> dict[str, int]:
+    """Convert a date to week and weekyear for the requested weekly standard."""
+    if not isinstance(date_input, datetime.date):
+        raise TypeError(
+            f"date_input must be a datetime.date, got {type(date_input).__name__}"
+        )
+    if standard not in ["epiweek", "isoweek"]:
+        raise ValueError("standard must be one of {'epiweek', 'isoweek'}")
+
+    if standard == "epiweek":
+        epiweek = epiweeks.Week.fromdate(date_input)
+        return {
+            "week": epiweek.week,
+            "weekyear": epiweek.year,
+        }
+
+    isocal = date_input.isocalendar()
+    return {
+        "week": isocal.week,
+        "weekyear": isocal.year,
+    }
+
+
+def calculate_week_startdate(
+    year: int,
+    week: int,
+    standard: WeekStandard = "epiweek",
+) -> datetime.date:
+    """Given a week and year, return the week start date."""
+    if standard not in ["epiweek", "isoweek"]:
+        raise ValueError("standard must be one of {'epiweek', 'isoweek'}")
+    if standard == "epiweek":
+        return epiweeks.Week(year, week).startdate()
+
+    return datetime.date.fromisocalendar(year, week, 1)
+
+
+def calculate_week_enddate(
+    year: int,
+    week: int,
+    standard: WeekStandard = "epiweek",
+) -> datetime.date:
+    """Given a week and year, return the week end date."""
+    if standard not in ["epiweek", "isoweek"]:
+        raise ValueError("standard must be one of {'epiweek', 'isoweek'}")
+    if standard == "epiweek":
+        return epiweeks.Week(year, week).enddate()
+
+    return datetime.date.fromisocalendar(year, week, 7)
+
+
+def daily_to_weekly(
+    df: pl.DataFrame,
+    value_col: str = "value",
+    date_col: str = "date",
+    id_cols: str | list[str] = ".draw",
+    weekly_value_name: str = "weekly_value",
+    standard: WeekStandard = "epiweek",
+    with_week_start_date: bool = False,
+    with_week_end_date: bool = False,
+    week_start_date_name: str = "week_start_date",
+    week_end_date_name: str = "week_end_date",
+    strict: bool = True,
+) -> pl.DataFrame:
+    """
+    Aggregate a dataframe of daily values to weekly totals.
+
+    Parameters
+    ----------
+    df
+        Tidy data frame of daily values to aggregate.
+    value_col
+        Name of the column containing daily values. Defaults to ``"value"``.
+    date_col
+        Name of the date column. Defaults to ``"date"``.
+    id_cols
+        Column name(s) that uniquely identify a single timeseries.
+    weekly_value_name
+        Name for the output weekly value column.
+        Defaults to ``"weekly_value"``.
+    standard
+        Weekly standard used to compute week and weekyear.
+        Must be one of ``"epiweek"`` or ``"isoweek"``.
+        Defaults to ``"epiweek"``.
+    with_week_start_date
+        Whether to annotate output with week start date.
+    with_week_end_date
+        Whether to annotate output with week end date.
+    week_start_date_name
+        Name for the output week start-date column.
+        Defaults to ``"week_start_date"``.
+    week_end_date_name
+        Name for the output week end-date column.
+        Defaults to ``"week_end_date"``.
+    strict
+        If ``True``, only aggregate weeks with exactly seven dates.
+
+    Returns
+    -------
+    pl.DataFrame
+        Dataframe with weekly aggregated values and optionally week metadata.
+    """
+    if value_col not in df.columns:
+        raise ValueError(
+            f"Specified value column '{value_col}' is missing from the dataframe"
+        )
+    if date_col not in df.columns:
+        raise ValueError(
+            f"Specified date column '{date_col}' is missing from the dataframe"
+        )
+    if standard not in ["epiweek", "isoweek"]:
+        raise ValueError("standard must be one of {'epiweek', 'isoweek'}")
+
+    if isinstance(id_cols, str):
+        id_cols = [id_cols]
+    else:
+        id_cols = list(id_cols)
+    missing_id_cols = [col for col in id_cols if col not in df.columns]
+    if missing_id_cols:
+        raise ValueError(
+            f"Specified trajectory id column(s) {missing_id_cols} are missing from the dataframe"
+        )
+
+    df = df.with_columns(
+        pl.col(date_col)
+        .map_elements(
+            lambda elt: calculate_week_and_year(elt, standard=standard),
+            return_dtype=pl.Struct(
+                [pl.Field("week", pl.Int64), pl.Field("weekyear", pl.Int64)]
+            ),
+        )
+        .alias("week_struct")
+    ).unnest("week_struct")
+
+    group_cols = ["week", "weekyear"] + id_cols
+    n_elements = df.group_by(group_cols).agg(pl.len().alias("n_elements"))
+    problematic_trajectories = n_elements.filter(pl.col("n_elements") > 7)
+    if not problematic_trajectories.is_empty():
+        message = (
+            "At least one trajectory has more than 7 values for a given "
+            f"week of a given weekyear.\n"
+            f"Problematic trajectories with more than 7 values: {problematic_trajectories}"
+        )
+        raise ValueError(message)
+
+    if strict:
+        valid_groups = n_elements.filter(pl.col("n_elements") == 7)
+        df = df.join(valid_groups.select(group_cols), on=group_cols, how="inner")
+
+    df = (
+        df.group_by(group_cols)
+        .agg(pl.col(value_col).sum().alias(weekly_value_name))
+        .sort(group_cols)
+    )
+
+    if with_week_start_date:
+        df = df.with_columns(
+            pl.struct(["weekyear", "week"])
+            .map_elements(
+                lambda elt: calculate_week_startdate(
+                    year=elt["weekyear"],
+                    week=elt["week"],
+                    standard=standard,
+                ),
+                return_dtype=pl.Date,
+            )
+            .alias(week_start_date_name)
+        )
+
+    if with_week_end_date:
+        df = df.with_columns(
+            pl.struct(["weekyear", "week"])
+            .map_elements(
+                lambda elt: calculate_week_enddate(
+                    year=elt["weekyear"],
+                    week=elt["week"],
+                    standard=standard,
+                ),
+                return_dtype=pl.Date,
+            )
+            .alias(week_end_date_name)
+        )
+
+    return df

--- a/cfa/stf/forecasttools/aggregate_to_weekly.py
+++ b/cfa/stf/forecasttools/aggregate_to_weekly.py
@@ -58,6 +58,91 @@ def _calculate_week_enddate(
     return epiweeks.Week(year, week, system=epiweek_standard).enddate()
 
 
+def floor_week(
+    date: datetime.date,
+    standard: WeekStandard | str = "MMWR",
+) -> datetime.date:
+    """Get the first date in an epidemiological week.
+
+    Given any date from an epidemiological week, return
+    the date of the first day of the epiweek,
+    according to the given epidemiological week standard.
+
+    Parameters
+    ----------
+    date
+        A date.
+    standard
+        One of ``"USA"`` or ``"MMWR"``
+        (USA / MMWR epiweek, starts on Sunday) and ``"ISO"``
+        (ISO week, starts on Monday). Not case-sensitive.
+
+    Returns
+    -------
+    datetime.date
+        The date that starts the epidemiological week.
+    """
+    week_info = _calculate_week_and_year(date, standard=standard)
+    return _calculate_week_startdate(
+        year=week_info["weekyear"],
+        week=week_info["week"],
+        standard=standard,
+    )
+
+
+def ceiling_week(
+    date: datetime.date,
+    standard: WeekStandard | str = "MMWR",
+) -> datetime.date:
+    """Get the last date in an epidemiological week.
+
+    Given any date from an epidemiological week, return
+    the date of the final day of the epiweek,
+    according to the given epidemiological week standard.
+
+    Parameters
+    ----------
+    date
+        A date.
+    standard
+        One of ``"USA"`` or ``"MMWR"``
+        (USA / MMWR epiweek, starts on Sunday) and ``"ISO"``
+        (ISO week, starts on Monday). Not case-sensitive.
+
+    Returns
+    -------
+    datetime.date
+        The date that ends the epidemiological week.
+
+    """
+    week_info = _calculate_week_and_year(date, standard=standard)
+    return _calculate_week_enddate(
+        year=week_info["weekyear"],
+        week=week_info["week"],
+        standard=standard,
+    )
+
+
+def floor_isoweek(date: datetime.date) -> datetime.date:
+    """Get the first date (Monday) in an ISO week."""
+    return floor_week(date, standard="ISO")
+
+
+def ceiling_isoweek(date: datetime.date) -> datetime.date:
+    """Get the last date (Sunday) in an ISO week."""
+    return ceiling_week(date, standard="ISO")
+
+
+def floor_mmwr_epiweek(date: datetime.date) -> datetime.date:
+    """Get the first date (Sunday) in an MMWR epidemiological week."""
+    return floor_week(date, standard="MMWR")
+
+
+def ceiling_mmwr_epiweek(date: datetime.date) -> datetime.date:
+    """Get the last date (Saturday) in an MMWR epidemiological week."""
+    return ceiling_week(date, standard="MMWR")
+
+
 def daily_to_weekly(
     df: pl.DataFrame,
     value_col: str = "value",

--- a/cfa/stf/forecasttools/aggregate_to_weekly.py
+++ b/cfa/stf/forecasttools/aggregate_to_weekly.py
@@ -4,61 +4,58 @@ from typing import Literal
 import epiweeks
 import polars as pl
 
-WeekStandard = Literal["epiweek", "isoweek"]
+WeekStandard = Literal["MMWR", "USA", "ISO"]
 
 
-def calculate_week_and_year(
-    date_input: datetime.date,
-    standard: WeekStandard = "epiweek",
+def _normalize_week_standard(standard: WeekStandard | str) -> Literal["cdc", "iso"]:
+    """Normalize week standard labels."""
+    normalized = standard.upper()
+    if normalized in ["MMWR", "USA"]:
+        return "cdc"
+    if normalized in ["ISO"]:
+        return "iso"
+
+    raise ValueError(
+        "standard must be one of {'MMWR', 'USA', 'ISO'} (not case-sensitive)"
+    )
+
+
+def _calculate_week_and_year(
+    date_input: datetime.date | datetime.datetime,
+    standard: WeekStandard | str = "MMWR",
 ) -> dict[str, int]:
     """Convert a date to week and weekyear for the requested weekly standard."""
     if not isinstance(date_input, datetime.date):
         raise TypeError(
-            f"date_input must be a datetime.date, got {type(date_input).__name__}"
+            f"date_input must be either a datetime.date or datetime.datetime, got {type(date_input).__name__}"
         )
-    if standard not in ["epiweek", "isoweek"]:
-        raise ValueError("standard must be one of {'epiweek', 'isoweek'}")
+    epiweek_standard = _normalize_week_standard(standard)
 
-    if standard == "epiweek":
-        epiweek = epiweeks.Week.fromdate(date_input)
-        return {
-            "week": epiweek.week,
-            "weekyear": epiweek.year,
-        }
-
-    isocal = date_input.isocalendar()
+    epiweek = epiweeks.Week.fromdate(date_input, system=epiweek_standard)
     return {
-        "week": isocal.week,
-        "weekyear": isocal.year,
+        "week": epiweek.week,
+        "weekyear": epiweek.year,
     }
 
 
-def calculate_week_startdate(
+def _calculate_week_startdate(
     year: int,
     week: int,
-    standard: WeekStandard = "epiweek",
+    standard: WeekStandard | str = "MMWR",
 ) -> datetime.date:
     """Given a week and year, return the week start date."""
-    if standard not in ["epiweek", "isoweek"]:
-        raise ValueError("standard must be one of {'epiweek', 'isoweek'}")
-    if standard == "epiweek":
-        return epiweeks.Week(year, week).startdate()
-
-    return datetime.date.fromisocalendar(year, week, 1)
+    epiweek_standard = _normalize_week_standard(standard)
+    return epiweeks.Week(year, week, system=epiweek_standard).startdate()
 
 
-def calculate_week_enddate(
+def _calculate_week_enddate(
     year: int,
     week: int,
-    standard: WeekStandard = "epiweek",
+    standard: WeekStandard | str = "MMWR",
 ) -> datetime.date:
     """Given a week and year, return the week end date."""
-    if standard not in ["epiweek", "isoweek"]:
-        raise ValueError("standard must be one of {'epiweek', 'isoweek'}")
-    if standard == "epiweek":
-        return epiweeks.Week(year, week).enddate()
-
-    return datetime.date.fromisocalendar(year, week, 7)
+    epiweek_standard = _normalize_week_standard(standard)
+    return epiweeks.Week(year, week, system=epiweek_standard).enddate()
 
 
 def daily_to_weekly(
@@ -67,7 +64,7 @@ def daily_to_weekly(
     date_col: str = "date",
     id_cols: str | list[str] = ".draw",
     weekly_value_name: str = "weekly_value",
-    standard: WeekStandard = "epiweek",
+    standard: WeekStandard | str = "MMWR",
     with_week_start_date: bool = False,
     with_week_end_date: bool = False,
     week_start_date_name: str = "week_start_date",
@@ -92,8 +89,9 @@ def daily_to_weekly(
         Defaults to ``"weekly_value"``.
     standard
         Weekly standard used to compute week and weekyear.
-        Must be one of ``"epiweek"`` or ``"isoweek"``.
-        Defaults to ``"epiweek"``.
+        One of ``"MMWR"`` or ``"USA"`` (Sunday start) and ``"ISO"``
+        (Monday start). Not case-sensitive.
+        Defaults to ``"MMWR"``.
     with_week_start_date
         Whether to annotate output with week start date.
     with_week_end_date
@@ -120,8 +118,6 @@ def daily_to_weekly(
         raise ValueError(
             f"Specified date column '{date_col}' is missing from the dataframe"
         )
-    if standard not in ["epiweek", "isoweek"]:
-        raise ValueError("standard must be one of {'epiweek', 'isoweek'}")
 
     if isinstance(id_cols, str):
         id_cols = [id_cols]
@@ -136,7 +132,7 @@ def daily_to_weekly(
     df = df.with_columns(
         pl.col(date_col)
         .map_elements(
-            lambda elt: calculate_week_and_year(elt, standard=standard),
+            lambda elt: _calculate_week_and_year(elt, standard=standard),
             return_dtype=pl.Struct(
                 [pl.Field("week", pl.Int64), pl.Field("weekyear", pl.Int64)]
             ),
@@ -169,7 +165,7 @@ def daily_to_weekly(
         df = df.with_columns(
             pl.struct(["weekyear", "week"])
             .map_elements(
-                lambda elt: calculate_week_startdate(
+                lambda elt: _calculate_week_startdate(
                     year=elt["weekyear"],
                     week=elt["week"],
                     standard=standard,
@@ -183,7 +179,7 @@ def daily_to_weekly(
         df = df.with_columns(
             pl.struct(["weekyear", "week"])
             .map_elements(
-                lambda elt: calculate_week_enddate(
+                lambda elt: _calculate_week_enddate(
                     year=elt["weekyear"],
                     week=elt["week"],
                     standard=standard,

--- a/cfa/stf/forecasttools/aggregate_to_weekly.py
+++ b/cfa/stf/forecasttools/aggregate_to_weekly.py
@@ -255,7 +255,7 @@ def daily_to_weekly(
         grouped_df = grouped_df.filter(pl.col("n_unique_dates") == 7)
 
     grouped_df = grouped_df.drop(["n_dates", "n_unique_dates"]).sort(
-        ["weekyear", "week", *id_cols]
+        [*id_cols, "weekyear", "week"]
     )
 
     if with_week_start_date:

--- a/cfa/stf/forecasttools/aggregate_to_weekly.py
+++ b/cfa/stf/forecasttools/aggregate_to_weekly.py
@@ -239,7 +239,7 @@ def daily_to_weekly(
     if not problematic_trajectories.is_empty():
         message = (
             "At least one trajectory has more than 7 values for a given "
-            f"week of a given weekyear.\n"
+            f"week.\n"
             f"Problematic trajectories with more than 7 values: {problematic_trajectories}"
         )
         raise ValueError(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "numpy>=2.2",
   "polars[numpy,pyarrow]>=1.36",
   "xarray[io]>=2025.10.1",
+  "epiweeks",
 ]
 
 [project.urls]

--- a/tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py
+++ b/tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py
@@ -93,13 +93,13 @@ def test_daily_to_weekly_invalid_standard_raises():
         ("ISO", datetime.date(2016, 1, 2), 2015, 53),
         ("USA", datetime.date(2016, 1, 3), 2016, 1),
         ("ISO", datetime.date(2016, 1, 3), 2015, 53),
-        ("MMWR", datetime.date(2021, 1, 3), 2021, 1),
-        ("ISO", datetime.date(2021, 1, 3), 2020, 53),
+        ("MMWR", datetime.datetime(2021, 1, 3), 2021, 1),
+        ("ISO", datetime.datetime(2021, 1, 3), 2020, 53),
     ],
 )
 def test_calculate_week_and_year_boundary_diverge(
     standard: str,
-    date_input: datetime.date,
+    date_input: datetime.date | datetime.datetime,
     expected_weekyear: int,
     expected_week: int,
 ):
@@ -213,5 +213,30 @@ def test_floor_ceiling_week_with_standard(
     date_input, standard, expected_floor, expected_ceiling
 ):
     """Test floor_week and ceiling_week with various standards (case-insensitive)."""
+    assert floor_week(date_input, standard=standard) == expected_floor
+    assert ceiling_week(date_input, standard=standard) == expected_ceiling
+
+
+@pytest.mark.parametrize(
+    ("date_input", "standard", "expected_floor", "expected_ceiling"),
+    [
+        (
+            datetime.datetime(2026, 3, 12, 18, 45),
+            "ISO",
+            datetime.date(2026, 3, 9),
+            datetime.date(2026, 3, 15),
+        ),
+        (
+            datetime.datetime(2026, 3, 12, 18, 45),
+            "MMWR",
+            datetime.date(2026, 3, 8),
+            datetime.date(2026, 3, 14),
+        ),
+    ],
+)
+def test_floor_ceiling_week_supports_datetime_input(
+    date_input, standard, expected_floor, expected_ceiling
+):
+    """Datetime inputs should still resolve to date week boundaries."""
     assert floor_week(date_input, standard=standard) == expected_floor
     assert ceiling_week(date_input, standard=standard) == expected_ceiling

--- a/tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py
+++ b/tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py
@@ -1,0 +1,114 @@
+"""
+Tests for daily_to_epiweekly.py functions.
+"""
+
+import datetime
+
+import polars as pl
+import pytest
+
+from cfa.stf.forecasttools import daily_to_weekly
+
+
+@pytest.mark.parametrize(
+    ("standard", "start_date", "expected_week_start_date", "expected_week_end_date"),
+    [
+        (
+            "epiweek",
+            datetime.date(2025, 10, 4),
+            datetime.date(2025, 10, 5),
+            datetime.date(2025, 10, 11),
+        ),
+        (
+            "isoweek",
+            datetime.date(2025, 10, 4),
+            datetime.date(2025, 10, 6),
+            datetime.date(2025, 10, 12),
+        ),
+    ],
+)
+def test_daily_to_weekly_supports_standards(
+    standard: str,
+    start_date: datetime.date,
+    expected_week_start_date: datetime.date,
+    expected_week_end_date: datetime.date,
+):
+    """Test aggregation behavior for each supported weekly standard."""
+    df = pl.DataFrame(
+        {
+            "location": ["TX"] * 10,
+            "date": [start_date + datetime.timedelta(days=i) for i in range(10)],
+            "value": [1] * 10,
+        }
+    )
+
+    out = daily_to_weekly(
+        df=df,
+        id_cols=["location"],
+        standard=standard,
+        with_week_start_date=True,
+        with_week_end_date=True,
+    )
+
+    assert out.get_column("week").item() == 41
+    assert out.get_column("weekyear").item() == 2025
+    assert out.get_column("week_start_date").item() == expected_week_start_date
+    assert out.get_column("week_end_date").item() == expected_week_end_date
+    assert out.get_column("weekly_value").item() == 7
+
+
+def test_daily_to_weekly_invalid_standard_raises():
+    """Unknown standard values should be rejected."""
+    df = pl.DataFrame(
+        {
+            ".draw": [0] * 7,
+            "date": [
+                datetime.date(2025, 10, 6) + datetime.timedelta(days=i)
+                for i in range(7)
+            ],
+            "value": [1] * 7,
+        }
+    )
+
+    with pytest.raises(ValueError, match="standard"):
+        daily_to_weekly(df=df, standard="mystandard")
+
+
+@pytest.mark.parametrize(
+    ("standard", "date_input", "expected_weekyear", "expected_week"),
+    [
+        ("epiweek", datetime.date(2015, 12, 31), 2015, 52),
+        ("isoweek", datetime.date(2015, 12, 31), 2015, 53),
+        ("epiweek", datetime.date(2016, 1, 1), 2015, 52),
+        ("isoweek", datetime.date(2016, 1, 1), 2015, 53),
+        ("epiweek", datetime.date(2016, 1, 2), 2015, 52),
+        ("isoweek", datetime.date(2016, 1, 2), 2015, 53),
+        ("epiweek", datetime.date(2016, 1, 3), 2016, 1),
+        ("isoweek", datetime.date(2016, 1, 3), 2015, 53),
+        ("epiweek", datetime.date(2021, 1, 3), 2021, 1),
+        ("isoweek", datetime.date(2021, 1, 3), 2020, 53),
+    ],
+)
+def test_calculate_week_and_year_boundary_diverge(
+    standard: str,
+    date_input: datetime.date,
+    expected_weekyear: int,
+    expected_week: int,
+):
+    df = pl.DataFrame(
+        {
+            "location": ["TX"],
+            "date": [date_input],
+            "value": [1],
+        }
+    )
+
+    out = daily_to_weekly(
+        df=df,
+        id_cols=["location"],
+        standard=standard,
+        strict=False,
+    )
+
+    assert out.get_column("week").item() == expected_week
+    assert out.get_column("weekyear").item() == expected_weekyear

--- a/tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py
+++ b/tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py
@@ -240,3 +240,37 @@ def test_floor_ceiling_week_supports_datetime_input(
     """Datetime inputs should still resolve to date week boundaries."""
     assert floor_week(date_input, standard=standard) == expected_floor
     assert ceiling_week(date_input, standard=standard) == expected_ceiling
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_duplicate_dates_are_rejected(strict):
+    """Duplicate dates in a weekly group should raise an error"""
+    sunday = datetime.date(2026, 1, 4)
+    dates = [sunday] + [sunday + datetime.timedelta(days=i) for i in range(6)]
+
+    df = pl.DataFrame(
+        {
+            ".draw": [0] * 7,
+            "date": dates,
+            "value": [1] * 7,
+        }
+    )
+
+    with pytest.raises(ValueError, match="repeated dates"):
+        daily_to_weekly(df, strict=strict)
+
+
+def test_multi_year_output_is_chronological():
+    start = datetime.date(2025, 12, 21)
+
+    df = pl.DataFrame(
+        {
+            ".draw": [0] * 21,
+            "date": [start + datetime.timedelta(days=i) for i in range(21)],
+            "value": [1] * 21,
+        }
+    )
+
+    result = daily_to_weekly(df)
+    actual = list(zip(result["weekyear"], result["week"]))
+    assert actual == [(2025, 52), (2025, 53), (2026, 1)]

--- a/tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py
+++ b/tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py
@@ -14,13 +14,13 @@ from cfa.stf.forecasttools import daily_to_weekly
     ("standard", "start_date", "expected_week_start_date", "expected_week_end_date"),
     [
         (
-            "epiweek",
+            "MMWR",
             datetime.date(2025, 10, 4),
             datetime.date(2025, 10, 5),
             datetime.date(2025, 10, 11),
         ),
         (
-            "isoweek",
+            "ISO",
             datetime.date(2025, 10, 4),
             datetime.date(2025, 10, 6),
             datetime.date(2025, 10, 12),
@@ -77,16 +77,16 @@ def test_daily_to_weekly_invalid_standard_raises():
 @pytest.mark.parametrize(
     ("standard", "date_input", "expected_weekyear", "expected_week"),
     [
-        ("epiweek", datetime.date(2015, 12, 31), 2015, 52),
-        ("isoweek", datetime.date(2015, 12, 31), 2015, 53),
-        ("epiweek", datetime.date(2016, 1, 1), 2015, 52),
-        ("isoweek", datetime.date(2016, 1, 1), 2015, 53),
-        ("epiweek", datetime.date(2016, 1, 2), 2015, 52),
-        ("isoweek", datetime.date(2016, 1, 2), 2015, 53),
-        ("epiweek", datetime.date(2016, 1, 3), 2016, 1),
-        ("isoweek", datetime.date(2016, 1, 3), 2015, 53),
-        ("epiweek", datetime.date(2021, 1, 3), 2021, 1),
-        ("isoweek", datetime.date(2021, 1, 3), 2020, 53),
+        ("MMWR", datetime.date(2015, 12, 31), 2015, 52),
+        ("ISO", datetime.date(2015, 12, 31), 2015, 53),
+        ("USA", datetime.date(2016, 1, 1), 2015, 52),
+        ("iso", datetime.date(2016, 1, 1), 2015, 53),
+        ("mmwr", datetime.date(2016, 1, 2), 2015, 52),
+        ("ISO", datetime.date(2016, 1, 2), 2015, 53),
+        ("USA", datetime.date(2016, 1, 3), 2016, 1),
+        ("ISO", datetime.date(2016, 1, 3), 2015, 53),
+        ("MMWR", datetime.date(2021, 1, 3), 2021, 1),
+        ("ISO", datetime.date(2021, 1, 3), 2020, 53),
     ],
 )
 def test_calculate_week_and_year_boundary_diverge(

--- a/tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py
+++ b/tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py
@@ -7,7 +7,15 @@ import datetime
 import polars as pl
 import pytest
 
-from cfa.stf.forecasttools import daily_to_weekly
+from cfa.stf.forecasttools import (
+    ceiling_isoweek,
+    ceiling_mmwr_epiweek,
+    ceiling_week,
+    daily_to_weekly,
+    floor_isoweek,
+    floor_mmwr_epiweek,
+    floor_week,
+)
 
 
 @pytest.mark.parametrize(
@@ -112,3 +120,98 @@ def test_calculate_week_and_year_boundary_diverge(
 
     assert out.get_column("week").item() == expected_week
     assert out.get_column("weekyear").item() == expected_weekyear
+
+
+@pytest.mark.parametrize(
+    ("date_input", "expected_floor", "expected_ceiling"),
+    [
+        (
+            datetime.date(2026, 3, 9),
+            datetime.date(2026, 3, 9),
+            datetime.date(2026, 3, 15),
+        ),
+        (
+            datetime.date(2026, 3, 12),
+            datetime.date(2026, 3, 9),
+            datetime.date(2026, 3, 15),
+        ),
+        (
+            datetime.date(2026, 3, 15),
+            datetime.date(2026, 3, 9),
+            datetime.date(2026, 3, 15),
+        ),
+    ],
+)
+def test_iso_week_floor_ceiling(date_input, expected_floor, expected_ceiling):
+    """Test floor_isoweek and ceiling_isoweek with ISO standard (Monday start)."""
+    assert floor_isoweek(date_input) == expected_floor
+    assert ceiling_isoweek(date_input) == expected_ceiling
+
+
+@pytest.mark.parametrize(
+    ("date_input", "expected_floor", "expected_ceiling"),
+    [
+        (
+            datetime.date(2026, 3, 8),
+            datetime.date(2026, 3, 8),
+            datetime.date(2026, 3, 14),
+        ),
+        (
+            datetime.date(2026, 3, 12),
+            datetime.date(2026, 3, 8),
+            datetime.date(2026, 3, 14),
+        ),
+        (
+            datetime.date(2026, 3, 14),
+            datetime.date(2026, 3, 8),
+            datetime.date(2026, 3, 14),
+        ),
+    ],
+)
+def test_mmwr_week_floor_ceiling(date_input, expected_floor, expected_ceiling):
+    """Test floor_mmwr_epiweek and ceiling_mmwr_epiweek with MMWR standard (Sunday start)."""
+    assert floor_mmwr_epiweek(date_input) == expected_floor
+    assert ceiling_mmwr_epiweek(date_input) == expected_ceiling
+
+
+@pytest.mark.parametrize(
+    ("date_input", "standard", "expected_floor", "expected_ceiling"),
+    [
+        (
+            datetime.date(2026, 3, 12),
+            "iso",
+            datetime.date(2026, 3, 9),
+            datetime.date(2026, 3, 15),
+        ),
+        (
+            datetime.date(2026, 3, 12),
+            "ISO",
+            datetime.date(2026, 3, 9),
+            datetime.date(2026, 3, 15),
+        ),
+        (
+            datetime.date(2026, 3, 12),
+            "USA",
+            datetime.date(2026, 3, 8),
+            datetime.date(2026, 3, 14),
+        ),
+        (
+            datetime.date(2026, 3, 12),
+            "MMWR",
+            datetime.date(2026, 3, 8),
+            datetime.date(2026, 3, 14),
+        ),
+        (
+            datetime.date(2026, 3, 12),
+            "mmwr",
+            datetime.date(2026, 3, 8),
+            datetime.date(2026, 3, 14),
+        ),
+    ],
+)
+def test_floor_ceiling_week_with_standard(
+    date_input, standard, expected_floor, expected_ceiling
+):
+    """Test floor_week and ceiling_week with various standards (case-insensitive)."""
+    assert floor_week(date_input, standard=standard) == expected_floor
+    assert ceiling_week(date_input, standard=standard) == expected_ceiling

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'ARM64' and sys_platform == 'win32'",
@@ -182,6 +182,7 @@ name = "cfa-stf-forecasttools"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "epiweeks" },
     { name = "numpy" },
     { name = "polars", extra = ["numpy", "pyarrow"] },
     { name = "xarray", extra = ["io"] },
@@ -202,6 +203,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "epiweeks" },
     { name = "numpy", specifier = ">=2.2" },
     { name = "polars", extras = ["numpy", "pyarrow"], specifier = ">=1.36" },
     { name = "xarray", extras = ["io"], specifier = ">=2025.10.1" },
@@ -507,6 +509,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl", hash = "sha256:2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d", size = 21592, upload-time = "2024-05-23T14:13:55.283Z" },
+]
+
+[[package]]
+name = "epiweeks"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/51/8b749e2756cc739cf2a5009ae8d4dbf6ca110e2ac59916351a5c2948ba82/epiweeks-2.4.0.tar.gz", hash = "sha256:0096132a50cfc4b52b2bfc8cf841d278740414d01cac303df05146db8b526539", size = 21004, upload-time = "2026-01-07T19:01:37.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/cf/66d80e94012fedb1ad9edb3053281685ad920b14dcd5e7166a48bbd1f168/epiweeks-2.4.0-py3-none-any.whl", hash = "sha256:a40cdde09b47530e7703d3d75248bb4ae2eb340f23af7c4c50e708b2e733e101", size = 5826, upload-time = "2026-01-07T19:01:35.669Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
What changed from previous forecasttools-py version:
- support for two standards: epiweek and isoweek
- option to append column with week start/end date (this is needed for backtest eval data)