### PR TITLE
Drop invalid values before weekly aggregation

### DIFF
--- a/cfa/stf/forecasttools/aggregate_to_weekly.py
+++ b/cfa/stf/forecasttools/aggregate_to_weekly.py
@@ -222,16 +222,21 @@ def daily_to_weekly(
             f"Specified trajectory id column(s) {missing_id_cols} are missing from the dataframe"
         )
 
-    df = df.with_columns(
-        pl.col(date_col)
-        .map_elements(
-            lambda elt: _calculate_week_and_year(elt, standard=standard),
-            return_dtype=pl.Struct(
-                [pl.Field("week", pl.Int64), pl.Field("weekyear", pl.Int64)]
-            ),
+    df = (
+        df.drop_nulls(value_col)
+        .drop_nans(value_col)
+        .with_columns(
+            pl.col(date_col)
+            .map_elements(
+                lambda elt: _calculate_week_and_year(elt, standard=standard),
+                return_dtype=pl.Struct(
+                    [pl.Field("week", pl.Int64), pl.Field("weekyear", pl.Int64)]
+                ),
+            )
+            .alias("week_struct")
         )
-        .alias("week_struct")
-    ).unnest("week_struct")
+        .unnest("week_struct")
+    )
 
     group_cols = ["week", "weekyear"] + id_cols
     grouped_df = df.group_by(group_cols).agg(

--- a/tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py
+++ b/tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py
@@ -82,6 +82,34 @@ def test_daily_to_weekly_invalid_standard_raises():
         daily_to_weekly(df=df, standard="mystandard")
 
 
+def _assert_daily_to_weekly_drops(invalid_value):
+    start = datetime.date(2026, 1, 4)
+    df = pl.DataFrame(
+        {
+            ".draw": [0] * 7 + [1] * 7,
+            "date": [start + datetime.timedelta(days=i) for i in range(7)] * 2,
+            "incidence": [1.0, invalid_value, 1.0, 1.0, 1.0, 1.0, 1.0]
+            + [invalid_value] * 7,
+        }
+    )
+
+    strict_out = daily_to_weekly(df, value_col="incidence")
+    non_strict_out = daily_to_weekly(df, value_col="incidence", strict=False)
+
+    assert strict_out.is_empty()
+    assert non_strict_out.select(".draw", "weekly_value").rows() == [(0, 6.0)]
+
+
+def test_daily_to_weekly_drops_nulls():
+    """Nulls should be removed before weekly aggregation."""
+    _assert_daily_to_weekly_drops(None)
+
+
+def test_daily_to_weekly_drops_nans():
+    """NaNs should be removed before weekly aggregation."""
+    _assert_daily_to_weekly_drops(float("nan"))
+
+
 @pytest.mark.parametrize(
     ("standard", "date_input", "expected_weekyear", "expected_week"),
     [


### PR DESCRIPTION
## Summary

- Drop null values from `value_col` with Polars' `drop_nulls` before weekly aggregation.
- Drop NaN values from `value_col` with Polars' `drop_nans` before weekly aggregation.
- Add separate regression tests for null and NaN removal under strict and non-strict aggregation.

## Why

Polars' sum can silently treat an all-null group as zero, while NaN values can contaminate an aggregate. Removing those rows before grouping ensures invalid observations do not count toward week completeness and prevents all-invalid trajectories from producing misleading zero totals.

## Impact

With `strict=True`, weeks containing a null or NaN value are incomplete and excluded. With `strict=False`, the remaining valid daily values are summed. Trajectories with no valid daily values are omitted.

## Validation

- `uv run pytest -q` (46 passed)
- `uv run ruff check cfa/stf/forecasttools/aggregate_to_weekly.py tests/cfa/stf/forecasttools/test_aggregate_to_weekly.py`
- `git diff --check`
