### PR TITLE
Parse tabular dates by default

### DIFF
--- a/cfa/stf/forecasttools/__init__.py
+++ b/cfa/stf/forecasttools/__init__.py
@@ -15,7 +15,7 @@ from .append_prop_data import append_prop_data
 from .augment_samples_with_observations import augment_samples_with_observations
 from .create_proportions import create_proportions
 from .location_table import LOCATION_LIST
-from .utils import coalesce_common_columns, read_tabular
+from .utils import coalesce_common_columns, read_tabular, write_tabular
 
 
 def __getattr__(name):
@@ -29,6 +29,7 @@ def __getattr__(name):
 __all__ = [
     "coalesce_common_columns",
     "read_tabular",
+    "write_tabular",
     "append_prop_data",
     "augment_samples_with_observations",
     "create_proportions",

--- a/cfa/stf/forecasttools/utils.py
+++ b/cfa/stf/forecasttools/utils.py
@@ -45,6 +45,9 @@ def read_tabular(path_to_file: str | Path, **kwargs: Any) -> pl.DataFrame:
     """
     file_format = Path(path_to_file).suffix.removeprefix(".").lower()
 
+    if file_format in {"csv", "tsv"}:
+        kwargs.setdefault("try_parse_dates", True)
+
     if file_format == "csv":
         return pl.read_csv(path_to_file, **kwargs)
     if file_format == "tsv":

--- a/cfa/stf/forecasttools/utils.py
+++ b/cfa/stf/forecasttools/utils.py
@@ -63,6 +63,49 @@ def read_tabular(path_to_file: str | Path, **kwargs: Any) -> pl.DataFrame:
     )
 
 
+def write_tabular(
+    table: pl.DataFrame, path_to_file: str | Path, **kwargs: Any
+) -> None:
+    """Write a table, inferring its format from the file extension.
+
+    Parameters
+    ----------
+    table
+        Polars DataFrame to write.
+    path_to_file
+        Path to a ``.csv``, ``.tsv``, or ``.parquet`` file. The extension is
+        matched case-insensitively.
+    **kwargs
+        Additional keyword arguments passed to
+        :meth:`polars.DataFrame.write_csv` or
+        :meth:`polars.DataFrame.write_parquet`, depending on the inferred
+        format.
+
+    Raises
+    ------
+    ValueError
+        If the path does not have a supported file extension.
+    """
+    file_format = Path(path_to_file).suffix.removeprefix(".").lower()
+
+    if file_format == "csv":
+        table.write_csv(path_to_file, **kwargs)
+        return
+    if file_format == "tsv":
+        kwargs.setdefault("separator", "\t")
+        table.write_csv(path_to_file, **kwargs)
+        return
+    if file_format == "parquet":
+        table.write_parquet(path_to_file, **kwargs)
+        return
+
+    supported_formats = ".csv, .tsv, and .parquet"
+    raise ValueError(
+        f"Unsupported file extension {Path(path_to_file).suffix!r}; "
+        f"expected one of {supported_formats}."
+    )
+
+
 def coalesce_common_columns(
     df: pl.DataFrame, suffix: str, new_colname: str | None = None
 ) -> pl.DataFrame:

--- a/cfa/stf/forecasttools/utils.py
+++ b/cfa/stf/forecasttools/utils.py
@@ -63,9 +63,7 @@ def read_tabular(path_to_file: str | Path, **kwargs: Any) -> pl.DataFrame:
     )
 
 
-def write_tabular(
-    table: pl.DataFrame, path_to_file: str | Path, **kwargs: Any
-) -> None:
+def write_tabular(table: pl.DataFrame, path_to_file: str | Path, **kwargs: Any) -> None:
     """Write a table, inferring its format from the file extension.
 
     Parameters

--- a/tests/cfa/stf/forecasttools/test_read_tabular.py
+++ b/tests/cfa/stf/forecasttools/test_read_tabular.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
 import polars as pl
@@ -49,6 +49,27 @@ def test_read_tabular_forwards_reader_options(tmp_path):
     result = ft.read_tabular(path, n_rows=2)
 
     assert result.get_column("value").to_list() == [1, 2]
+
+
+@pytest.mark.parametrize(
+    ("file_format", "separator"), [("csv", ","), ("tsv", "\t")]
+)
+def test_read_tabular_parses_dates_by_default(tmp_path, file_format, separator):
+    path = tmp_path / f"dates.{file_format}"
+    path.write_text(f"date{separator}value\n2026-01-15{separator}1\n")
+
+    result = ft.read_tabular(path)
+
+    assert result.get_column("date").to_list() == [date(2026, 1, 15)]
+
+
+def test_read_tabular_allows_disabling_date_parsing(tmp_path):
+    path = tmp_path / "dates.csv"
+    path.write_text("date,value\n2026-01-15,1\n")
+
+    result = ft.read_tabular(path, try_parse_dates=False)
+
+    assert result.get_column("date").to_list() == ["2026-01-15"]
 
 
 def test_read_tabular_corrects_timezone_naive_parquet_timestamps(tmp_path):

--- a/tests/cfa/stf/forecasttools/test_read_tabular.py
+++ b/tests/cfa/stf/forecasttools/test_read_tabular.py
@@ -51,9 +51,7 @@ def test_read_tabular_forwards_reader_options(tmp_path):
     assert result.get_column("value").to_list() == [1, 2]
 
 
-@pytest.mark.parametrize(
-    ("file_format", "separator"), [("csv", ","), ("tsv", "\t")]
-)
+@pytest.mark.parametrize(("file_format", "separator"), [("csv", ","), ("tsv", "\t")])
 def test_read_tabular_parses_dates_by_default(tmp_path, file_format, separator):
     path = tmp_path / f"dates.{file_format}"
     path.write_text(f"date{separator}value\n2026-01-15{separator}1\n")

--- a/tests/cfa/stf/forecasttools/test_read_tabular.py
+++ b/tests/cfa/stf/forecasttools/test_read_tabular.py
@@ -21,12 +21,7 @@ def tabular_data():
 @pytest.mark.parametrize("file_format", ["csv", "tsv", "parquet"])
 def test_read_tabular_reads_supported_formats(tmp_path, tabular_data, file_format):
     path = tmp_path / f"data.{file_format}"
-    if file_format == "csv":
-        tabular_data.write_csv(path)
-    elif file_format == "tsv":
-        tabular_data.write_csv(path, separator="\t")
-    else:
-        tabular_data.write_parquet(path)
+    ft.write_tabular(tabular_data, path)
 
     result = ft.read_tabular(path)
 
@@ -35,7 +30,7 @@ def test_read_tabular_reads_supported_formats(tmp_path, tabular_data, file_forma
 
 def test_read_tabular_matches_extension_case_insensitively(tmp_path, tabular_data):
     path = tmp_path / "data.CSV"
-    tabular_data.write_csv(path)
+    ft.write_tabular(tabular_data, path)
 
     result = ft.read_tabular(path)
 
@@ -44,26 +39,27 @@ def test_read_tabular_matches_extension_case_insensitively(tmp_path, tabular_dat
 
 def test_read_tabular_forwards_reader_options(tmp_path):
     path = tmp_path / "data.csv"
-    path.write_text("value\n1\n2\n3\n")
+    ft.write_tabular(pl.DataFrame({"value": [1, 2, 3]}), path)
 
     result = ft.read_tabular(path, n_rows=2)
 
     assert result.get_column("value").to_list() == [1, 2]
 
 
-@pytest.mark.parametrize(("file_format", "separator"), [("csv", ","), ("tsv", "\t")])
-def test_read_tabular_parses_dates_by_default(tmp_path, file_format, separator):
+@pytest.mark.parametrize("file_format", ["csv", "tsv"])
+def test_read_tabular_parses_dates_by_default(tmp_path, file_format):
     path = tmp_path / f"dates.{file_format}"
-    path.write_text(f"date{separator}value\n2026-01-15{separator}1\n")
+    data = pl.DataFrame({"date": [date(2026, 1, 15)], "value": [1]})
+    ft.write_tabular(data, path)
 
     result = ft.read_tabular(path)
 
-    assert result.get_column("date").to_list() == [date(2026, 1, 15)]
+    plt.assert_frame_equal(result, data)
 
 
 def test_read_tabular_allows_disabling_date_parsing(tmp_path):
     path = tmp_path / "dates.csv"
-    path.write_text("date,value\n2026-01-15,1\n")
+    ft.write_tabular(pl.DataFrame({"date": [date(2026, 1, 15)], "value": [1]}), path)
 
     result = ft.read_tabular(path, try_parse_dates=False)
 
@@ -83,7 +79,7 @@ def test_read_tabular_corrects_timezone_naive_parquet_timestamps(tmp_path):
             "timestamp_with_timezone": pl.Datetime("us", "Asia/Tokyo"),
         },
     )
-    data.write_parquet(path)
+    ft.write_tabular(data, path)
 
     result = ft.read_tabular(path)
 
@@ -104,3 +100,11 @@ def test_read_tabular_rejects_unsupported_extensions(tmp_path, filename):
 
     with pytest.raises(ValueError, match="Unsupported file extension"):
         ft.read_tabular(path)
+
+
+@pytest.mark.parametrize("filename", ["data.json", "data"])
+def test_write_tabular_rejects_unsupported_extensions(tmp_path, filename):
+    path = tmp_path / filename
+
+    with pytest.raises(ValueError, match="Unsupported file extension"):
+        ft.write_tabular(pl.DataFrame(), path)


### PR DESCRIPTION
## Summary

- enable Polars date parsing by default for CSV and TSV files read through read_tabular
- preserve the ability to opt out with try_parse_dates=False
- cover default CSV/TSV parsing and the explicit opt-out

## Verification

- uv run pytest
- uv run ruff check .
- uv build

Follow-up to #238