### PR TITLE
Write NA for null tabular values

### DIFF
--- a/cfa/stf/forecasttools/utils.py
+++ b/cfa/stf/forecasttools/utils.py
@@ -87,6 +87,9 @@ def write_tabular(table: pl.DataFrame, path_to_file: str | Path, **kwargs: Any) 
     """
     file_format = Path(path_to_file).suffix.removeprefix(".").lower()
 
+    if file_format in {"csv", "tsv"}:
+        kwargs.setdefault("null_value", "NA")
+
     if file_format == "csv":
         table.write_csv(path_to_file, **kwargs)
         return

--- a/tests/cfa/stf/forecasttools/test_read_tabular.py
+++ b/tests/cfa/stf/forecasttools/test_read_tabular.py
@@ -114,6 +114,26 @@ def test_read_tabular_corrects_timezone_naive_parquet_timestamps(tmp_path):
     ).row(0)
 
 
+@pytest.mark.parametrize("file_format", ["csv", "tsv"])
+def test_write_tabular_writes_na_for_null_by_default(tmp_path, file_format):
+    path = tmp_path / f"data.{file_format}"
+    data = pl.DataFrame({"location": ["US"], "value": [None]})
+
+    ft.write_tabular(data, path)
+
+    separator = "," if file_format == "csv" else "\t"
+    assert path.read_text() == f"location{separator}value\nUS{separator}NA\n"
+
+
+def test_write_tabular_allows_overriding_null_value(tmp_path):
+    path = tmp_path / "data.csv"
+    data = pl.DataFrame({"value": [None]})
+
+    ft.write_tabular(data, path, null_value="missing")
+
+    assert path.read_text() == "value\nmissing\n"
+
+
 @pytest.mark.parametrize("filename", ["data.json", "data"])
 def test_read_tabular_rejects_unsupported_extensions(tmp_path, filename):
     path = tmp_path / filename


### PR DESCRIPTION
## Summary
- default `write_tabular` to serialize nulls as `NA` for CSV and TSV files
- preserve explicit `null_value` overrides
- test the default behavior for both text formats and the override path

## Testing
- `uv run pytest` (73 passed)